### PR TITLE
add fallbacks to meta tags

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -43,6 +43,8 @@ module.exports = Generator.extend({
           ['s3bucket']: 'graphics.axios.com',
           ['s3folder']: dateString + '-' + slugify(this.appname),
           ['slug']: slugify(this.appname),
+          ['appleFallback']: `fallbacks/${slugify(this.appname)}-apple.png`,
+          ['newsletterFallback']: `fallbacks/${slugify(this.appname)}-fallback.png`,
         };
       }.bind(this));
     }

--- a/generators/app/templates/gulp/templates.js
+++ b/generators/app/templates/gulp/templates.js
@@ -43,7 +43,8 @@ module.exports = () => {
         'img': imageUrl,
         'toFixed2': toFixed2
       })
-      .data(config.paths.src.data + '/**/*.{js,json}');
+      .data(config.paths.src.data + '/**/*.{js,json}')
+      .data(config.paths.projectConfig);
 
   // Production tasks.
   var prdTasks = lazypipe()

--- a/generators/app/templates/project.config.json
+++ b/generators/app/templates/project.config.json
@@ -9,5 +9,7 @@
   },
   "files": [],
   "isFullbleed": false,
+  "appleFallback": "<%= meta.appleFallback %>",
+  "newsletterFallback": "<%= meta.newsletterFallback %>",
   "embedVersion": "1.0"  
 }

--- a/generators/app/templates/src/templates/layouts/base.hbs
+++ b/generators/app/templates/src/templates/layouts/base.hbs
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
     <meta property="fullbleed" content="<%= meta.isFullbleed %>" />
     <meta property="slug" content="<%= meta.slug %>" />
-    <meta property="apple-fallback" content="<%= meta.appleFallback %>" />
-    <meta property="newsletter-fallback" content="<%= meta.newsletterFallback %>" />
+    <meta property="apple-fallback" content="{{ projectConfig.appleFallback }}" />
+    <meta property="newsletter-fallback" content="{{ projectConfig.newsletterFallback }}" />
     <link rel="icon" type="image/png" href="https://static.axios.com/img/axiosvisuals-favicon-128x128.png" sizes="128x128" />
     <link rel="stylesheet" type="text/css" href="{{static 'css/main.css'}}">
     <title><%= meta.name %> | Axios</title>

--- a/generators/app/templates/src/templates/layouts/base.hbs
+++ b/generators/app/templates/src/templates/layouts/base.hbs
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
     <meta property="fullbleed" content="<%= meta.isFullbleed %>" />
     <meta property="slug" content="<%= meta.slug %>" />
+    <meta property="apple-fallback" content="<%= meta.appleFallback %>" />
+    <meta property="newsletter-fallback" content="<%= meta.newsletterFallback %>" />
     <link rel="icon" type="image/png" href="https://static.axios.com/img/axiosvisuals-favicon-128x128.png" sizes="128x128" />
     <link rel="stylesheet" type="text/css" href="{{static 'css/main.css'}}">
     <title><%= meta.name %> | Axios</title>

--- a/generators/app/templates/src/templates/layouts/base.hbs
+++ b/generators/app/templates/src/templates/layouts/base.hbs
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
-    <meta property="fullbleed" content="<%= meta.isFullbleed %>" />
-    <meta property="slug" content="<%= meta.slug %>" />
+    <meta property="fullbleed" content="{{ projectConfig.isFullbleed }}" />
+    <meta property="slug" content="{{ projectConfig.project.slug }}" />
     <meta property="apple-fallback" content="{{ projectConfig.appleFallback }}" />
     <meta property="newsletter-fallback" content="{{ projectConfig.newsletterFallback }}" />
     <link rel="icon" type="image/png" href="https://static.axios.com/img/axiosvisuals-favicon-128x128.png" sizes="128x128" />


### PR DESCRIPTION
auto generate fallback filenames based on folder name (aka the slug)

## Open questions
* altering `templates.js` to read from project.config.json conflicts with the templating behavior of the dependent card deck generator