### PR TITLE
easier `opts` merging into module and extra padding on axis ticks

### DIFF
--- a/generators/app/templates/src/js/chart-template.js
+++ b/generators/app/templates/src/js/chart-template.js
@@ -3,7 +3,7 @@ let d3 = require("d3");
 class makeChart {
 
     constructor(opts) {
-        this.element = opts.element;
+        Object.assign(this,opts)
         this.aspectHeight = opts.aspectHeight ? opts.aspectHeight : .68;
 
         this.update();
@@ -61,18 +61,19 @@ class makeChart {
             .attr("class", "chart-g");
 
         this.xAxis = d3.axisBottom(this.xScale)
-            .tickSize(-this.height);
+            .tickSize(-this.height-20);
 
         this.yAxis = d3.axisLeft(this.yScale)
-            .tickSize(-this.width);
+            .tickSize(-this.width-20);
 
         this.plot.append("g")
             .classed("axis x-axis", true)
-            .attr("transform", "translate(0," + this.height + ")")
+            .attr("transform", "translate(0," + (this.height+20) + ")")
             .call(this.xAxis);
 
         this.plot.append("g")
             .classed("axis y-axis", true)
+            .attr("transform", "translate(" + (-20) + ",0)")
             .call(this.yAxis);
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "",
   "scripts": {
-    "setup": "pip3 install awscli && npm install -g yo gulp-cli && npm install && npm link"
+    "setup": "pip install awscli && npm install -g yo gulp-cli && npm install && npm link"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This does three small things.

`Object.assign(this,opts)` will take all properties in `opts` and merge them into `this`. This is good because we don't have to do it manually for each extra one we add. 

The other small changes adds longer ticks that extend beyond the domain per out style.