### PR TITLE
Fix slug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 .DS_Store
 .yo-rc.json
+.vscode

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -42,7 +42,7 @@ module.exports = Generator.extend({
           ['name']: this.appname,
           ['s3bucket']: 'graphics.axios.com',
           ['s3folder']: dateString + '-' + slugify(this.appname),
-          ['slug']: slugify(this.appname),
+          ['slug']: dateString + '-' + slugify(this.appname),
           ['appleFallback']: `fallbacks/${slugify(this.appname)}-apple.png`,
           ['newsletterFallback']: `fallbacks/${slugify(this.appname)}-fallback.png`,
         };


### PR DESCRIPTION
Didn't catch this earlier. Slugs should match s3 folder path so they can be used in EDEN to find fallback images