### PR TITLE
upgrade pym

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "axios-feta": "axioscode/feta#v0.0.4",
-    "pym.js": "^1.3.1"
+    "pym.js": "^1.3.2"
   },
   "devDependencies": {
     "d3" : "^4.9.1",


### PR DESCRIPTION
future projects will use v1.3.2. we'll still need to assess the vulnerability to say whether past graphics need to be updated as well