### PR TITLE
Add Greenkeeper

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,15 @@ pipeline {
       }
     }
 
+    stage("Prep Greenkeeper") {
+      when {
+        branch "greenkeeper/**"
+      }
+      steps {
+        greenkeeper("update")
+      }
+    }
+
     stage ("Install dependencies") {
       agent {
         docker {
@@ -75,6 +84,15 @@ pipeline {
           echo 'n' | yarn yo axios --force
           yarn webpack -p
         """
+      }
+    }
+
+    stage("Finish Greenkeeper") {
+      when {
+        branch "greenkeeper/**"
+      }
+      steps {
+        greenkeeper("upload")
       }
     }
   }

--- a/greekeeper.json
+++ b/greekeeper.json
@@ -1,0 +1,7 @@
+{
+  "groups": {
+    "default": {
+      "packages": ["package.json", "generators/app/templates/package.json"]
+    }
+  }
+}


### PR DESCRIPTION
# Purpose
This repo had its second security vulnerability warning this weekend. Although we were lucky since it did not touch production, Greenkeeper can help us keep packages up-to-date going forward.